### PR TITLE
fix signature of reMock

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,7 +30,8 @@ interface FetchMockStatic {
     mock(matcher: MockMatcher, method?: string, response?: MockResponse | MockMatcherFunction): this;
     restore(): this;
     reset(): this;
-    reMock(): this;
+    reMock(matcher: MockMatcher, response?: MockResponse | MockResponseFunction): this;
+    reMock(matcher: MockMatcher, method?: string, response?: MockResponse | MockMatcherFunction): this;
 
     calls(matcher?: string): Array<MockCall>
     calls(): MatchedRoutes;


### PR DESCRIPTION
The signature of reMock is the same as mock.

See https://github.com/wheresrhys/fetch-mock/blob/master/src/fetch-mock.js#L343.
